### PR TITLE
update soname

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,5 +1,6 @@
 #########################################################################
 # Copyright (c) 2021, Xilinx Inc. and Contributors. All rights reserved.
+# Copyright (C) 2022 - 2024 Advanced Micro Devices, Inc. All Rights Reserved.
 # SPDX-License-Identifier: MIT
 #########################################################################
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -4,7 +4,7 @@
 #########################################################################
 
 #PROJECT_VERSION should match with yocto recipe version for SOVERSION
-set (PROJECT_VERSION_MAJOR 1)
+set (PROJECT_VERSION_MAJOR 2)
 set (PROJECT_VERSION_MINOR 0)
 set (PROJECT_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR})
 message (STATUS "dfx-mgr version: ${PROJECT_VERSION} (${CMAKE_SOURCE_DIR})")


### PR DESCRIPTION
New version of dfx-mgr that is going to be released has some breaking changes compare to the version released in ubuntu which is 2023.2

So we need update the so name since the changes are not backwards compatible.