### PR TITLE
Ubuntu Core enablement changes

### DIFF
--- a/example/sys/linux/dfx-mgr-client.c
+++ b/example/sys/linux/dfx-mgr-client.c
@@ -290,7 +290,7 @@ int main(int argc, char *argv[])
 				return -1;
 			}
 			if (recv_message.data[0] == '-'){
-				printf("Load Error: %s: ", recv_message.data);
+				printf("Load Error: %s\n", recv_message.data);
 				return -1;
 			} else {
 				printf("Loaded with slot_handle %s\n", recv_message.data);

--- a/src/daemon_helper.c
+++ b/src/daemon_helper.c
@@ -1152,7 +1152,7 @@ char *listAccelerators()
 
 	memset(res,0, sizeof(res));
 	firmware_dir_walk();
- 
+
 	sprintf(msg, header_format, "#", "Accel_type", "user_load_type", "user_load_region", "Base", "Pid",
 		"Base_type", "#slots(RPU+PL+AIE)", "slot->handle", "Accelerator");
 	strcat(res,msg);
@@ -1722,7 +1722,7 @@ static int user_load_overlay(char *ov, char *region)
 	struct stat sb;
 	FILE *fptr;
 
-	snprintf(ov_dir, sizeof(ov_dir), "/configfs/device-tree/overlays/%s", region);
+	snprintf(ov_dir, sizeof(ov_dir), "/sys/kernel/config/device-tree/overlays/%s", region);
 	if (((stat(ov_dir, &sb) == 0) && S_ISDIR(sb.st_mode))) {
 		DFX_ERR("Overlay already exists in the live tree");
 		return -1;
@@ -1961,7 +1961,7 @@ int user_unload_overlay(char *region)
 		return -1;
 	}
 
-	snprintf(ov_dir, sizeof(ov_dir), "/configfs/device-tree/overlays/%s", region);
+	snprintf(ov_dir, sizeof(ov_dir), "/sys/kernel/config/device-tree/overlays/%s", region);
 	if (((stat(ov_dir, &sb) == 0) && S_ISDIR(sb.st_mode))) {
 		snprintf(command, sizeof(command), "rmdir %s", ov_dir);
 		if (system(command)) {
@@ -2051,16 +2051,13 @@ static void init_user_load(void)
 	    }
     }
 
-    FD = opendir("/configfs/device-tree/overlays/");
+    FD = opendir("/sys/kernel/config/device-tree/overlays/");
     if (FD)
 	    closedir(FD);
     else {
-	    if (system("mkdir -p /configfs")) {
-		    DFX_ERR("Failed system() API");
-	    }
-	    if (system("mount -t configfs configfs /configfs")) {
-		    DFX_ERR("Failed system() API");
-	    }
+    	DFX_ERR("/sys/kernel/config/device-tree/overlays/ not present on the system. "
+	     "Is configfs enabled in kernel config?");
+
     }
 }
 

--- a/src/daemon_helper.c
+++ b/src/daemon_helper.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <dirent.h>
 #include <unistd.h>
+#include <libgen.h>
 #include <dfx-mgr/accel.h>
 #include <dfx-mgr/assert.h>
 #include <dfx-mgr/shell.h>
@@ -26,6 +27,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <semaphore.h>
+#include <libdfx.h>
 
 struct daemon_config config;
 struct watch *active_watch = NULL;
@@ -1694,7 +1696,6 @@ static int fpga_state(void)
 static int user_load_sysfs(char *bin)
 {
 	char command[2048];
-
 	snprintf(command, sizeof(command), "echo %s > /sys/class/fpga_manager/fpga0/firmware", bin);
 	if (system(command)) {
 		DFX_ERR("Failed system() API");
@@ -1853,11 +1854,6 @@ int user_load(int flag, char *binfile, char *overlay, char *region)
 		bin = token;
 	}
 
-	snprintf(command, sizeof(command), "cp %s /lib/firmware", binfile);
-	if (system(command)) {
-		DFX_ERR("Failed system() API");
-	}
-
 	snprintf(command, sizeof(command), "echo %x > /sys/class/fpga_manager/fpga0/flags", flag & 1);
 	if (system(command)) {
 		DFX_ERR("Failed system() API");
@@ -1878,62 +1874,46 @@ int user_load(int flag, char *binfile, char *overlay, char *region)
 		while((token = strsep(&tmp, "/"))) {
 			ov = token;
 		}
-
-		snprintf(command, sizeof(command), "cp %s /lib/firmware", overlay);
-		if (system(command)) {
-			DFX_ERR("Failed system() API");
-		}
-
+	    dfx_set_firmware_lookup_path(overlay);
 		rv = user_load_overlay(ov, region);
 	} else {
+	    dfx_set_firmware_lookup_path(binfile);
 		rv = user_load_sysfs(bin);
 	}
 
 	if (!rv) {
-		int i;
+	    int i;
 
-		/* get the free space in array to add new entry */
-		for (i = 0; (i < MAX_WATCH) && (base_designs[i].base_path[0] != '\0'); i++);
+	    /* get the free space in array to add new entry */
+	    for (i = 0; (i < MAX_WATCH) && (base_designs[i].base_path[0] != '\0'); i++);
 
-		if (i == MAX_WATCH) {
-			DFX_ERR("Unable to add new design, MAX limit (%d) reached.", MAX_WATCH);
-			user_unload_overlay(region);
-			rv = -1;
-		} else {
-			DFX_DBG("Adding user managed design %s", bin);
-			strncpy(base_designs[i].name, bin, sizeof(base_designs[i].name) - 1);
-			base_designs[i].name[sizeof(base_designs[i].name) - 1] = '\0';
-			strncpy(base_designs[i].base_path, "User", sizeof(base_designs[i].base_path) - 1);
-			base_designs[i].base_path[sizeof(base_designs[i].base_path) - 1] = '\0';
-			base_designs[i].active = 0;
-			base_designs[i].is_user_load = 1;
-			base_designs[i].user_load_type = flag & 1;
-			rv = base_designs[i].user_load_handle = get_free_slot_handle();
-			strncpy(base_designs[i].user_load_region, region ? region : "", sizeof(base_designs[i].user_load_region) - 1);
-			base_designs[i].user_load_region[sizeof(base_designs[i].user_load_region) - 1] = '\0';
+	    if (i == MAX_WATCH) {
+	        DFX_ERR("Unable to add new design, MAX limit (%d) reached.", MAX_WATCH);
+	        user_unload_overlay(region);
+	        rv = -1;
+	    } else {
+	        DFX_DBG("Adding user managed design %s", bin);
+	        strncpy(base_designs[i].name, bin, sizeof(base_designs[i].name) - 1);
+	        base_designs[i].name[sizeof(base_designs[i].name) - 1] = '\0';
+	        strncpy(base_designs[i].base_path, "User", sizeof(base_designs[i].base_path) - 1);
+	        base_designs[i].base_path[sizeof(base_designs[i].base_path) - 1] = '\0';
+	        base_designs[i].active = 0;
+	        base_designs[i].is_user_load = 1;
+	        base_designs[i].user_load_type = flag & 1;
+	        rv = base_designs[i].user_load_handle = get_free_slot_handle();
+	        strncpy(base_designs[i].user_load_region, region ? region : "", sizeof(base_designs[i].user_load_region) - 1);
+	        base_designs[i].user_load_region[sizeof(base_designs[i].user_load_region) - 1] = '\0';
 
-			if (base_designs[i].user_load_type && platform.active_base)
-				platform.active_base->active += 1;
-			else
-				platform.active_base = &base_designs[i];
-		}
+	        if (base_designs[i].user_load_type && platform.active_base)
+	            platform.active_base->active += 1;
+	        else
+	            platform.active_base = &base_designs[i];
+	    }
 	}
+
 
 ret:
-	if (bin != NULL) {
-		snprintf(command, sizeof(command), "rm /lib/firmware/%s", bin);
-		if (system(command)) {
-			DFX_ERR("Failed system() API");
-		}
-	}
-
-	if (ov != NULL) {
-		snprintf(command, sizeof(command), "rm /lib/firmware/%s", ov);
-		if (system(command)) {
-			DFX_ERR("Failed system() API");
-		}
-	}
-
+    dfx_set_firmware_lookup_path("");
 	return rv;
 }
 
@@ -2041,15 +2021,6 @@ int user_unload(int handle)
 static void init_user_load(void)
 {
     DIR *FD;
-    FD = opendir("/lib/firmware");
-
-    if (FD) {
-	    closedir(FD);
-    } else {
-	    if (system("mkdir -p /lib/firmware")) {
-		    DFX_ERR("Failed system() API");
-	    }
-    }
 
     FD = opendir("/sys/kernel/config/device-tree/overlays/");
     if (FD)

--- a/src/daemon_helper.c
+++ b/src/daemon_helper.c
@@ -29,6 +29,10 @@
 #include <semaphore.h>
 #include <libdfx.h>
 
+#ifndef DTBO_ROOT_DIR
+#define DTBO_ROOT_DIR "/sys/kernel/config/device-tree/overlays"
+#endif
+
 struct daemon_config config;
 struct watch *active_watch = NULL;
 struct basePLDesign *base_designs = NULL;
@@ -1654,33 +1658,84 @@ firmware_dir_walk(void)
  */
 static int fpga_state(void)
 {
-	FILE *fptr;
-	char buf[10];
-	char *state_operating = "operating";
-	char *state_unknown = "unknown";
+    const char *state_operating = "operating";
+    const char *state_unknown = "unknown";
+    char read_buf[128];
 
-	if (system("cat /sys/class/fpga_manager/fpga0/state >> state.txt")) {
-		DFX_ERR("Failed system() API");
-		return -1;
-	}
-	fptr = fopen("state.txt", "r");
-	if (fptr) {
-		if (fgets(buf, 10, fptr) == NULL) {
-			DFX_ERR("Failed to read fpga state");
-			buf[0] = 0;
-		}
-		fclose(fptr);
-		if (system("rm state.txt")) {
-			DFX_ERR("Failed system() API");
-		}
-		if ((strncmp(buf, state_operating, 9) == 0) || (strncmp(buf, state_unknown, 7) == 0))
-			return 0;
-		else
-			return -1;
-	}
+    if (dfx_get_fpga_state(read_buf, sizeof(read_buf)) < 0) {
+        DFX_ERR("Failed to determine the fpga state -"
+        " could not read state file");
+        return -1;
+    }
 
-	return -1;
+    DFX_DBG("FPGA state read as: `%s`", read_buf);
+
+    if (strcmp(read_buf, state_operating) == 0 ||
+        strcmp(read_buf, state_unknown) == 0) {
+        return 0;
+        }
+
+    DFX_ERR("FPGA is in a bad state. State: `%s`", read_buf);
+    return -1;
 }
+
+/**
+ * check_overlay_was_applied(...) - check that an overlay was applied
+ *
+ *
+ * @overlay_dir:      Path to the overlay directory in configfs.
+ * @requested_path:   The overlay path to write to the `path` attribute.
+ *
+ * This function checks that an overlay was properly applied by reading
+ * the overlay status and the overlay path by checking files in the configfs.
+ * It checks that "applied" is in the overlay's `status` attribute
+ * and that the `path` attribute contains the requested_path, i.e. the overlay
+ * file which was requested
+ *
+ * Return: 0 if the overlay status "applied" and path matches requested_path,
+ *        -1 on error or if either assertion is false
+ */
+static int check_overlay_was_applied(const char *overlay_dir, const char *requested_path)
+{
+    char read_buf[128];
+    const char *state_applied = "applied";
+
+
+    /* Check overlay path */
+    if (dfx_get_overlay_path(overlay_dir, read_buf, sizeof(read_buf)) < 0) {
+        DFX_ERR("Failed to check the overlay was applied -"
+                " could not read path file");
+        return -1;
+    }
+
+    DFX_DBG("Overlay path read as: `%s`", read_buf);
+
+    if (strcmp(read_buf, requested_path) != 0) {
+        DFX_ERR("Overlay path does not match written path:\n"
+                "\tRequested: `%s`\n"
+                "\tCurrent:   `%s`",
+                requested_path, read_buf);
+        return -1;
+    }
+
+    /* Check overlay status */
+    if (dfx_get_overlay_status(overlay_dir, read_buf, sizeof(read_buf)) < 0) {
+        DFX_ERR("Failed to check the overlay was applied -"
+                " could not read status file");
+        return -1;
+    }
+
+    DFX_DBG("Overlay status read as: `%s`", read_buf);
+
+    if (strcmp(read_buf, state_applied) != 0) {
+        DFX_ERR("Overlay status is `%s`, expected `%s`",
+                read_buf, state_applied);
+        return -1;
+    }
+
+    return 0;
+}
+
 
 /**
  * user_load_sysfs() - load FPGA firmware via sysfs.
@@ -1695,14 +1750,33 @@ static int fpga_state(void)
  */
 static int user_load_sysfs(char *bin)
 {
-	char command[2048];
-	snprintf(command, sizeof(command), "echo %s > /sys/class/fpga_manager/fpga0/firmware", bin);
-	if (system(command)) {
-		DFX_ERR("Failed system() API");
+	if (dfx_set_fpga_firmware(bin)) {
+		DFX_ERR("Failed to load firmware - failed to request bitstream load");
 		return -1;
 	}
+	if (fpga_state()) {
+		DFX_ERR("Failed to load firmware - write succeeded, but fpga reports"
+				" bad state (or state could not be determined)");
+		return -1;
+	}
+	return 0;
+}
 
-	return (fpga_state() == 0) ? 0 : -1;
+/**
+ * remove_overlay_dir() - remove device tree overlay from configfs interface.
+ *
+ * @dir: the overlay directory to be removed
+ *
+ * This function attempts to remove the directory provided, with additional logging.
+ *
+ */
+static void remove_overlay_dir(const char *dir)
+{
+	if (rmdir(dir) != 0) {
+		DFX_ERR("Failed to remove directory `%s`", dir);
+	} else {
+		DFX_DBG("Directory `%s` removed", dir);
+	}
 }
 
 /**
@@ -1717,63 +1791,38 @@ static int user_load_sysfs(char *bin)
  * Return: 0 on success,
  *        -1 on failure.
  */
-static int user_load_overlay(char *ov, char *region)
-{
-	char command[2048], ov_dir[512], buf[512];
+static int user_load_overlay(char *ov, char *region) {
+	char ov_dir[512];
+	char* overlays_root_path = DTBO_ROOT_DIR;
 	struct stat sb;
-	FILE *fptr;
 
-	snprintf(ov_dir, sizeof(ov_dir), "/sys/kernel/config/device-tree/overlays/%s", region);
+	snprintf(ov_dir, sizeof(ov_dir), "%s/%s", overlays_root_path, region);
 	if (((stat(ov_dir, &sb) == 0) && S_ISDIR(sb.st_mode))) {
 		DFX_ERR("Overlay already exists in the live tree");
 		return -1;
 	}
 
-	snprintf(command, sizeof(command), "mkdir %s", ov_dir);
-	if (system(command)) {
-		DFX_ERR("Failed system() API");
+	// here, mode (0755) is ignored by the kernel so can be anything.
+	if (mkdir(ov_dir, 0755)) {
+		DFX_ERR("Failed to create overlay dir");
 		return -1;
 	}
 
-	snprintf(command, sizeof(command), "echo -n %s > %s/path", ov, ov_dir);
-	if (system(command)) {
-		DFX_ERR("Failed system() API");
+	if (dfx_set_overlay_path(ov_dir, ov)) {
+		DFX_ERR("Failed to set overlay's source path");
+		remove_overlay_dir(ov_dir);
+		return -1;
 	}
 
-	snprintf(command, sizeof(command), "cat %s/path >> state.txt", ov_dir);
-	if (system(command)) {
-		DFX_ERR("Failed system() API");
-	}
-
-	fptr = fopen("state.txt", "r");
-	if (fptr) {
-		if (fgets(buf, strlen(ov) + 1, fptr) == NULL) {
-			DFX_ERR("Failed to read overlay path");
-			buf[0] = 0;
-		}
-		fclose(fptr);
-		if (system("rm state.txt")) {
-			DFX_ERR("Failed system() API");
-		}
-
-		if (!strcmp(buf, ov)) {
-			DFX_PR("Applied overlay");
-		} else {
-			DFX_ERR("Failed to apply Overlay");
-			return -1;
-		}
-	} else {
-		DFX_ERR("Failed to check overlay state");
+	if (check_overlay_was_applied(ov_dir, ov)) {
+		DFX_ERR("Overlay failed to apply - state or path was wrong");
+		remove_overlay_dir(ov_dir);
 		return -1;
 	}
 
 	if (fpga_state()) {
-		DFX_ERR("Failed to load bitstream. Removing overlay applied");
-		snprintf(command, sizeof(command), "rmdir %s", ov_dir);
-		if (system(command)) {
-			DFX_ERR("Failed system() API");
-		}
-
+		DFX_ERR("Bitstream loading failed during overlay application");
+		remove_overlay_dir(ov_dir);
 		return -1;
 	}
 
@@ -1803,9 +1852,8 @@ static int user_load_overlay(char *ov, char *region)
  * Return: An integer unique handle id on success,
  *        -1 on failure or if constraints are violated.
  */
-int user_load(int flag, char *binfile, char *overlay, char *region)
+int user_load(const int flag, char *binfile, char *overlay, char *region)
 {
-	char command[2048];
 	char *bin = NULL, *ov = NULL, *tmp, *token;
 	int rv = -1;
 
@@ -1854,11 +1902,12 @@ int user_load(int flag, char *binfile, char *overlay, char *region)
 		bin = token;
 	}
 
-	snprintf(command, sizeof(command), "echo %x > /sys/class/fpga_manager/fpga0/flags", flag & 1);
-	if (system(command)) {
-		DFX_ERR("Failed system() API");
+	// ignore bits >= 1, only care about partial or full.
+	if (dfx_set_fpga_flags(flag & 1)) {
+		DFX_ERR("Failed to set flags");
 	}
 
+	// Check between bitstream load via overlay, or direct.
 	if ((flag >> 1) & 1) {
 		if (region == NULL) {
 			DFX_ERR("Provide overlay region name");
@@ -1874,46 +1923,46 @@ int user_load(int flag, char *binfile, char *overlay, char *region)
 		while((token = strsep(&tmp, "/"))) {
 			ov = token;
 		}
-	    dfx_set_firmware_lookup_path(overlay);
+		dfx_set_firmware_search_path(overlay);
 		rv = user_load_overlay(ov, region);
 	} else {
-	    dfx_set_firmware_lookup_path(binfile);
+		dfx_set_firmware_search_path(binfile);
 		rv = user_load_sysfs(bin);
 	}
 
 	if (!rv) {
-	    int i;
+		int i;
 
-	    /* get the free space in array to add new entry */
-	    for (i = 0; (i < MAX_WATCH) && (base_designs[i].base_path[0] != '\0'); i++);
+		/* get the free space in array to add new entry */
+		for (i = 0; (i < MAX_WATCH) && (base_designs[i].base_path[0] != '\0'); i++);
 
-	    if (i == MAX_WATCH) {
-	        DFX_ERR("Unable to add new design, MAX limit (%d) reached.", MAX_WATCH);
-	        user_unload_overlay(region);
-	        rv = -1;
-	    } else {
-	        DFX_DBG("Adding user managed design %s", bin);
-	        strncpy(base_designs[i].name, bin, sizeof(base_designs[i].name) - 1);
-	        base_designs[i].name[sizeof(base_designs[i].name) - 1] = '\0';
-	        strncpy(base_designs[i].base_path, "User", sizeof(base_designs[i].base_path) - 1);
-	        base_designs[i].base_path[sizeof(base_designs[i].base_path) - 1] = '\0';
-	        base_designs[i].active = 0;
-	        base_designs[i].is_user_load = 1;
-	        base_designs[i].user_load_type = flag & 1;
-	        rv = base_designs[i].user_load_handle = get_free_slot_handle();
-	        strncpy(base_designs[i].user_load_region, region ? region : "", sizeof(base_designs[i].user_load_region) - 1);
-	        base_designs[i].user_load_region[sizeof(base_designs[i].user_load_region) - 1] = '\0';
+		if (i == MAX_WATCH) {
+			DFX_ERR("Unable to add new design, MAX limit (%d) reached.", MAX_WATCH);
+			user_unload_overlay(region);
+			rv = -1;
+		} else {
+			DFX_DBG("Adding user managed design %s", bin);
+			strncpy(base_designs[i].name, bin, sizeof(base_designs[i].name) - 1);
+			base_designs[i].name[sizeof(base_designs[i].name) - 1] = '\0';
+			strncpy(base_designs[i].base_path, "User", sizeof(base_designs[i].base_path) - 1);
+			base_designs[i].base_path[sizeof(base_designs[i].base_path) - 1] = '\0';
+			base_designs[i].active = 0;
+			base_designs[i].is_user_load = 1;
+			base_designs[i].user_load_type = flag & 1;
+			rv = base_designs[i].user_load_handle = get_free_slot_handle();
+			strncpy(base_designs[i].user_load_region, region ? region : "", sizeof(base_designs[i].user_load_region) - 1);
+			base_designs[i].user_load_region[sizeof(base_designs[i].user_load_region) - 1] = '\0';
 
-	        if (base_designs[i].user_load_type && platform.active_base)
-	            platform.active_base->active += 1;
-	        else
-	            platform.active_base = &base_designs[i];
-	    }
+			if (base_designs[i].user_load_type && platform.active_base)
+				platform.active_base->active += 1;
+			else
+				platform.active_base = &base_designs[i];
+		}
 	}
 
 
 ret:
-    dfx_set_firmware_lookup_path("");
+	dfx_set_firmware_search_path("");
 	return rv;
 }
 
@@ -1932,7 +1981,7 @@ ret:
  */
 int user_unload_overlay(char *region)
 {
-	char command[2048], ov_dir[512];
+	char ov_dir[512];
 	struct stat sb;
 	int i;
 
@@ -1941,12 +1990,9 @@ int user_unload_overlay(char *region)
 		return -1;
 	}
 
-	snprintf(ov_dir, sizeof(ov_dir), "/sys/kernel/config/device-tree/overlays/%s", region);
+	snprintf(ov_dir, sizeof(ov_dir), "%s/%s", DTBO_ROOT_DIR, region);
 	if (((stat(ov_dir, &sb) == 0) && S_ISDIR(sb.st_mode))) {
-		snprintf(command, sizeof(command), "rmdir %s", ov_dir);
-		if (system(command)) {
-			DFX_ERR("Failed system() API");
-		}
+	    remove_overlay_dir(ov_dir);
 
 		for (i = 0; (i < MAX_WATCH) && strncmp(base_designs[i].user_load_region, region, strlen(region) + 1); i++);
 		if (i == MAX_WATCH) {
@@ -2020,16 +2066,16 @@ int user_unload(int handle)
  */
 static void init_user_load(void)
 {
-    DIR *FD;
+	DIR *FD;
 
-    FD = opendir("/sys/kernel/config/device-tree/overlays/");
-    if (FD)
-	    closedir(FD);
-    else {
-    	DFX_ERR("/sys/kernel/config/device-tree/overlays/ not present on the system. "
-	     "Is configfs enabled in kernel config?");
+	FD = opendir(DTBO_ROOT_DIR);
+	if (FD)
+		closedir(FD);
+	else {
+		DFX_ERR("%s not present on the"
+	" system. Is configfs enabled in kernel config?", DTBO_ROOT_DIR);
 
-    }
+	}
 }
 
 #define BUF_LEN (10 * (sizeof(struct inotify_event) + NAME_MAX + 1))

--- a/src/daemon_helper.c
+++ b/src/daemon_helper.c
@@ -1748,7 +1748,7 @@ static int check_overlay_was_applied(const char *overlay_dir, const char *reques
  * Return: 0 on success,
  *        -1 on failure.
  */
-static int user_load_sysfs(char *bin)
+static int user_load_sysfs(const char *bin)
 {
 	if (dfx_set_fpga_firmware(bin)) {
 		DFX_ERR("Failed to load firmware - failed to request bitstream load");
@@ -1791,7 +1791,7 @@ static void remove_overlay_dir(const char *dir)
  * Return: 0 on success,
  *        -1 on failure.
  */
-static int user_load_overlay(char *ov, char *region) {
+static int user_load_overlay(const char *ov, const char *region) {
 	char ov_dir[512];
 	char* overlays_root_path = DTBO_ROOT_DIR;
 	struct stat sb;
@@ -1852,7 +1852,7 @@ static int user_load_overlay(char *ov, char *region) {
  * Return: An integer unique handle id on success,
  *        -1 on failure or if constraints are violated.
  */
-int user_load(const int flag, char *binfile, char *overlay, char *region)
+int user_load(const int flag, const char *binfile, const char *overlay, const char *region)
 {
 	char *bin = NULL, *ov = NULL, *tmp, *token;
 	int rv = -1;
@@ -1979,7 +1979,7 @@ ret:
  * Return: 0 on success,
  *        -1 on failure or if the overlay does not exist.
  */
-int user_unload_overlay(char *region)
+int user_unload_overlay(const char *region)
 {
 	char ov_dir[512];
 	struct stat sb;
@@ -2023,7 +2023,7 @@ int user_unload_overlay(char *region)
  * Return: 0 on success,
  *        -1 on failure or if the handle does not correspond to any loaded design.
  */
-int user_unload(int handle)
+int user_unload(const int handle)
 {
 	int i;
 
@@ -2079,7 +2079,7 @@ static void init_user_load(void)
 }
 
 #define BUF_LEN (10 * (sizeof(struct inotify_event) + NAME_MAX + 1))
-void *threadFunc(void *)
+void *threadFunc([[maybe_unused]] void *_)
 {
     int wd, j, ret;
     char buf[BUF_LEN] __attribute__ ((aligned(8)));

--- a/src/daemon_helper.h
+++ b/src/daemon_helper.h
@@ -44,9 +44,9 @@ char *listAccelerators();
 void getRMInfo();
 int dfx_init();
 int dfx_getFDs(int slot, int *fd);
-int user_load(int flag, char *binfile, char *overlay, char *region);
-int user_unload_overlay(char *region);
-int user_unload(int handle);
+int user_load(int flag, const char *binfile, const char *overlay, const char *region);
+int user_unload_overlay(const char *region);
+int user_unload(const int handle);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
In an ongoing attempt to enable fpga device functionality in Ubuntu Core, three issues have arisen in relation to the requirement for snaps to be strictly confined. In our case, we are attempting to redistribute dfx-mgr (and libdfx) as part of [FPGAd](github.com/canonical/fpgad). Once the concept of "softeners" is in place, this snap will enable downstream customers to use dfx-mgr as they expect to be able to, but with the caveat that FPGAd will be the gatekeeper for accessing the FPGA subsystems.

In these efforts, we found three challenges in the way dfx-mgr and libdfx operate:

1. both parts of this application write to a file called `state.txt`. In real operation, this file is created at `/state.txt` which is not allowed in a strictly confined snap, and no layout can be applied to files in the root directory, except as files inside known pre-defined directories. 
2. files are freely moved in and our of /lib/firmware. In a snap's environment, this directory does not exist, so accesses to it fail. Repeatedly copying is bad for performance as well.
3. the device tree overlay subsystem's files (configfs) are remounted to `/configfs`. This mount call requires strong permissions, which the store team can't/wont to grant to the fpgad snap. 

In order to tackle these three problems, I have edited dfx-mgr and libdfx with the following solutions:

1) for dfx-mgr, state.txt is now moved to ~`/etc/dfx-mgrd/state.txt`~ `/run/dfx-mgrd/state.txt`. I would actually prefer to remove the "system(command)" calls to mitigate the need for this file at all, but that is out of scope here. 
2) Before anything which will trigger the kernel to look for firmware, instead of copying files to /lib/firmware, the containing directory is written to `/sys/module/firmware_class/parameters/path` instead. The implementation is in libdfx.c/.h to avoid code duplication.
3) the calls to mount `/configfs` are removed, and all paths pointing to "/configfs/"  are replaced by `/sys/kernel/config/` 

Please see https://github.com/Xilinx/libdfx/pull/6 for the libdfx changes

Please do not hesitate to suggest changes or ask for clarification. 