### PR TITLE
CMakeLists: update cmake_minimum_required version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 #########################################################################
 
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 3.5)
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()


### PR DESCRIPTION
In ubuntu builds for resolute, cmake complains about dropped support for versions less than 3.5:
```
CMake Error at CMakeLists.txt:6 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

```

This change to increase minimum version to at least 3.5 allows us to continue building the package.