### PR TITLE
scripts: xlnx-firmware-load - remove `function` bashism

### DIFF
--- a/src/scripts/xlnx-firmware-load
+++ b/src/scripts/xlnx-firmware-load
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: MIT
 
 # Load firmware and check the return status
-function load_firmware() {
+load_firmware() {
 	fwname=$1
 	dfx-mgr-client -load "${fwname}"
 


### PR DESCRIPTION
The function keyword is not valid syntax for `sh` and the shebang is `#!/bin/sh`. 
Therefore this script will fail to run with `/usr/bin/xlnx-firmware-load: 8: Syntax error: "(" unexpected` when run as systemd service (as intended) unless the "function" keyword is removed. 
An alternative solution (less ideal) is to specify `#!/bin/bash` in the shebang.